### PR TITLE
remove protocollib from chmod list

### DIFF
--- a/script/server.sh
+++ b/script/server.sh
@@ -14,7 +14,7 @@ while true; do
 	# Make certain files and folders read-only
 
 	mkdir debug/ dumps/ plugins/update/
-	chmod -R 500 debug/ dumps/ plugins/bStats/ plugins/PluginMetrics/ plugins/ProtocolLib/ plugins/update/
+	chmod -R 500 debug/ dumps/ plugins/bStats/ plugins/PluginMetrics/ plugins/update/
 	chmod 500 plugins/
 	chmod 400 bukkit.yml
 	chmod 400 commands.yml


### PR DESCRIPTION
protocollib was removed from plugins list, so there's no need to chmod it's folder since it doesn't exist. saves you a error