### PR TITLE
give the OS some memory to rest

### DIFF
--- a/script/server.sh
+++ b/script/server.sh
@@ -33,7 +33,7 @@ while true; do
 	# Start Minecraft server
 
 	java \
-		-Xmx1800M \
+		-Xmx1700M \
 		-Xshare:on \
 		-Xss8M \
 		-XX:MaxDirectMemorySize=512M \


### PR DESCRIPTION
server has 1.87gb of ram, you allocate 1.8gb of ram, debian uses ~100mb of ram, minecraft server usage goes to 1.8gb of ram, system crashes. (how to crashloop kaboom 101)