### PR TITLE
Make the server automatically sync the changes with the github repo on restart.

### DIFF
--- a/script/reset.sh
+++ b/script/reset.sh
@@ -8,6 +8,10 @@ pkill -9 schematics.sh
 pkill -9 server.sh
 pkill -9 java
 
+# Sync changes with the github repository
+cd ~/server-default
+git pull
+
 chmod -R 777 ~/server/
 rm -rf ~/server/*
 cp -Tr ~/server-default/ ~/server/


### PR DESCRIPTION
There's no reason not to do this, since kaboom frequently is out of sync with the github repo. This would also force you to commit the changes to the github repo, instead of waiting 3-5 weeks to update the main repo.