### PR TITLE
Check 0.0.0.0 instead of play.kaboom.pw

### DIFF
--- a/script/alivecheck.sh
+++ b/script/alivecheck.sh
@@ -11,7 +11,7 @@ while true; do
 	# If server doesn't respond to ping, or if the log file is older than
 	# 3 minutes, kill the server
 
-	if [ "$(env printf '\xFE' | nc -w 15 play.kaboom.pw 25565 | wc -m)" -eq 0 ]; then
+	if [ "$(env printf '\xFE' | nc -w 15 0.0.0.0 25565 | wc -m)" -eq 0 ]; then
 		pkill -9 java
 		echo $(date) >> ~/kill.log
 	fi


### PR DESCRIPTION
This caused me a LOT of trouble in my server, it was getting killed for no reason and I didn't know why. And then I realized it.

(also kaboom is down @kaboombot )