### PR TITLE
Small improvements to scripts

### DIFF
--- a/script/server.sh
+++ b/script/server.sh
@@ -4,9 +4,6 @@
 
 PATH="$HOME/framework/vendor/java/bin/:$PATH"
 
-# Dump classes
-java -Xshare:dump
-
 # Make sure we're in the server folder, located in the home directory
 cd ~/server/
 
@@ -43,8 +40,9 @@ while true; do
 	# Start Minecraft server
 
 	java \
-		-Xms1700M \
-		-Xmx1700M \
+		-Xms1700M Xmx1700M \
+		\
+		-Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true \
 		-XX:+UseG1GC \
 		-XX:+ParallelRefProcEnabled \
 		-XX:MaxGCPauseMillis=200 \
@@ -65,14 +63,11 @@ while true; do
 		-XX:InitiatingHeapOccupancyPercent=15 \
 		-Xss8M \
 		-XX:MaxDirectMemorySize=512M \
-		-Xshare:on \
-		-XX:+UseContainerSupport \
+		\
 		-XX:-UsePerfData \
-		-DPaper.IgnoreJavaVersion=true \
-		-Dpaper.playerconnection.keepalive=360 \
+		-Dpaper.playerconnection.keepalive=60 \
 		-DIReallyKnowWhatIAmDoingISwear \
-		-Dusing.aikars.flags=https://mcflags.emc.gs \
-		-Daikars.new.flags=true \
+		\
 		-jar server.jar nogui
 
 	# Stop alive checker (will be started again on the next run)

--- a/vendor/generate_jre.sh
+++ b/vendor/generate_jre.sh
@@ -1,14 +1,54 @@
 #!/bin/sh
+set -e
+# This script is used to generate a stripped-down JRE for the server
 
-# This script is used as a reference to generate a stripped-down JRE for the server
+JDK_VERSION="21"
+JDK_OS="linux"
+JDK_ARCHITECTURE="x64"
 
-rm -rf java/
-curl -L https://download.java.net/java/GA/jdk21/fd2272bbf8e04c3dbaee13770090416c/35/GPL/openjdk-21_linux-x64_bin.tar.gz > openjdk.tar.gz
-tar -zxvf openjdk.tar.gz
-rm openjdk.tar.gz
-mv jdk* jdk/
-jdk/bin/jlink --no-header-files --no-man-pages --compress=2 --strip-debug \
+fetch() {
+	curl -fL \
+		--proto =http,https \
+		"$@"
+}
+
+download_extract() {
+	tar_path="$(mktemp --suffix=.tar.gz)"
+
+	exitcode=0
+	fetch -# "$1" -o "$tar_path" || exitcode=$?
+	if [ $exitcode != 0 ]; then
+		rm -f "$tar_path" 2>/dev/null
+		return $exitcode
+	fi
+
+	mkdir -p "$2"
+	tar \
+		--strip-components=1 \
+		-xf "$tar_path" \
+		-C "$2" || exitcode=$?
+	rm -f "$tar_path" 2>/dev/null
+
+	return $exitcode
+}
+
+JDK_URL="$(fetch -so- "https://api.adoptium.net/v3/assets/latest/$JDK_VERSION/hotspot" | \
+	jq --raw-output --exit-status \
+		--arg architecture "$JDK_ARCHITECTURE" --arg os "$JDK_OS" \
+		'.[].binary | select(.image_type == "jdk" and .architecture == $architecture and .os == $os) | .package.link')"
+
+[ -d jdk ] && rm -rf jdk
+echo "Downloading Adoptium $JDK_VERSION..."
+download_extract "$JDK_URL" jdk/
+
+[ -d java ] && rm -rf java
+echo "Building custom JRE..."
+jdk/bin/jlink --no-header-files --no-man-pages --strip-debug \
 	--exclude-files=**java_*.properties,**jrunscript,**keytool,**legal/** \
 	--add-modules java.desktop,java.instrument,java.logging,java.management,java.naming,java.net.http,java.scripting,java.sql,jdk.crypto.ec,jdk.security.auth,jdk.unsupported,jdk.zipfs \
 	--output java
-rm -rf jdk/
+rm -rf jdk
+
+echo "Generating shared classes..."
+java/bin/java -Xshare:dump
+


### PR DESCRIPTION
- Adoptium 21 is now used instead of the GA release for OpenJDK 21 as they offer extended updates.
- The class dump is generated once per JRE update instead of every server reboot, improving startup times by a few seconds
- Cleaned up some JVM startup flags and removed the `--compress=2` flag from jlink as it resulted in a warning (it's already the default).

This PR does not contain any changes to the JRE binaries, you will have to update those yourself.