### PR TITLE
26.1 preparations

### DIFF
--- a/script/server.sh
+++ b/script/server.sh
@@ -44,39 +44,25 @@ while true; do
 
 	java \
 		-Xms3400M -Xmx3400M \
-		\
-		-Dusing.aikars.flags=https://mcflags.emc.gs -Daikars.new.flags=true \
-		-XX:+UseG1GC \
-		-XX:+ParallelRefProcEnabled \
-		-XX:MaxGCPauseMillis=200 \
-		-XX:+UnlockExperimentalVMOptions \
-		-XX:+DisableExplicitGC \
-		-XX:+AlwaysPreTouch \
-		-XX:G1HeapWastePercent=5 \
-		-XX:G1MixedGCCountTarget=4 \
-		-XX:G1MixedGCLiveThresholdPercent=90 \
-		-XX:G1RSetUpdatingPauseTimePercent=5 \
-		-XX:SurvivorRatio=32 \
-		-XX:+PerfDisableSharedMem \
-		-XX:MaxTenuringThreshold=1 \
-		-XX:G1NewSizePercent=30 \
-		-XX:G1MaxNewSizePercent=40 \
-		-XX:G1HeapRegionSize=8M \
-		-XX:G1ReservePercent=20 \
-		-XX:InitiatingHeapOccupancyPercent=15 \
-		-Xss8M \
 		-XX:MaxDirectMemorySize=512M \
 		\
+		-XX:+UseZGC \
+		-XX:+UseCompactObjectHeaders \
+		-XX:+AlwaysPreTouch \
+		-XX:+UseStringDeduplication \
+		-Xss8M \
+		\
+		-XX:+DisableExplicitGC \
 		-XX:-UsePerfData \
+		-XX:+PerfDisableSharedMem \
 		-Dpaper.playerconnection.keepalive=60 \
-		-DIReallyKnowWhatIAmDoingISwear \
 		\
 		-jar server.jar nogui
 
 	# Stop alive checker (will be started again on the next run)
 
 	pkill -9 alivecheck.sh
-	echo $(date) >> "$stop_log_file"
+	date >> "$stop_log_file"
 
 	# Ensure we don't abuse the CPU in case of failure
 	sleep 1

--- a/vendor/generate_jre.sh
+++ b/vendor/generate_jre.sh
@@ -2,7 +2,7 @@
 set -e
 # This script is used to generate a stripped-down JRE for the server
 
-JDK_VERSION="21"
+JDK_VERSION="25"
 JDK_OS="linux"
 JDK_ARCHITECTURE="x64"
 


### PR DESCRIPTION
Minecraft 26.1 will require Java 25. As of [26.1-snapshot-2](https://www.minecraft.net/en-us/article/minecraft-26-1-snapshot-2), it will also use ZGC instead of G1GC as it's default garbage collector, so I switched Aikar's flags to just ZGC.

ZGC has a bit of memory overhead in exchange for incredibly short GC pause times. I think the UseCompactObjectHeaders flag will compensate for that memory overhead. Mojang turned this on by default as well, so it's most likely not going to break anything.

They also turned on UseStringDeduplication by default, and while I'm not sure how this will affect the server's CPU usage, I'm hoping it helps with memory usage a bit, especially considering the large strings people frequently use in NBT items and entities, so I enabled it here too.